### PR TITLE
Add callback executed when slide/fade/zoom end

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ const properties = {
   transitionDuration: 500,
   infinite: true,
   indicators: true,
-  onChange: (index) => { console.log(`Finished slide ${index}`) }
+  onChange: (oldIndex, newIndex) => {
+    console.log(`Finished slide ${oldIndex}, now slide ${newIndex} is shown`)
+  }
 }
 
 const Slideshow = () => {
@@ -72,7 +74,9 @@ const fadeProperties = {
   transitionDuration: 500,
   infinite: true,
   indicators: true,
-  onChange: (index) => { console.log(`Finished fade ${index}`) }
+  onChange: (oldIndex, newIndex) => {
+    console.log(`Finished slide ${oldIndex}, now slide ${newIndex} is shown`)
+  }
 }
 
 const Slideshow = () => {
@@ -122,7 +126,9 @@ const zoomOutProperties = {
   infinite: true,
   indicators: true,
   scale: 0.4,
-  onChange: (index) => { console.log(`Finished zoom ${index}`) }
+  onChange: (oldIndex, newIndex) => {
+    console.log(`Finished slide ${oldIndex}, now slide ${newIndex} is shown`)
+  }
 }
 
 const Slideshow = () => {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ const properties = {
   duration: 5000,
   transitionDuration: 500,
   infinite: true,
-  indicators: true
+  indicators: true,
+  onChange: (index) => { console.log(`Finished slide ${index}`) }
 }
 
 const Slideshow = () => {
@@ -70,7 +71,8 @@ const fadeProperties = {
   duration: 5000,
   transitionDuration: 500,
   infinite: true,
-  indicators: true
+  indicators: true,
+  onChange: (index) => { console.log(`Finished fade ${index}`) }
 }
 
 const Slideshow = () => {
@@ -119,7 +121,8 @@ const zoomOutProperties = {
   transitionDuration: 500,
   infinite: true,
   indicators: true,
-  scale: 0.4
+  scale: 0.4,
+  onChange: (index) => { console.log(`Finished zoom ${index}`) }
 }
 
 const Slideshow = () => {

--- a/lib/components/slideshow/fade.js
+++ b/lib/components/slideshow/fade.js
@@ -224,18 +224,16 @@ var Fade = function (_Component) {
         }
         _this5.setState({
           index: newIndex
+        }, function () {
+          try {
+            if (typeof onChange === "function") onChange(index, newIndex);
+          } catch (e) {
+            console.error(e);
+          }
         });
         _this5.timeout = setTimeout(function () {
           _this5.fadeImages((newIndex + 1) % children.length);
         }, _this5.props.duration);
-
-        try {
-          if (typeof onChange === "function") {
-            onChange(index);
-          }
-        } catch (e) {
-          console.error(e);
-        }
       });
     }
   }]);

--- a/lib/components/slideshow/fade.js
+++ b/lib/components/slideshow/fade.js
@@ -197,6 +197,7 @@ var Fade = function (_Component) {
       var _state2 = this.state,
           children = _state2.children,
           index = _state2.index;
+      var onChange = this.props.onChange;
 
       clearTimeout(this.timeout);
       var value = { opacity: 0 };
@@ -227,6 +228,14 @@ var Fade = function (_Component) {
         _this5.timeout = setTimeout(function () {
           _this5.fadeImages((newIndex + 1) % children.length);
         }, _this5.props.duration);
+
+        try {
+          if (typeof onChange === "function") {
+            onChange(index);
+          }
+        } catch (e) {
+          console.error(e);
+        }
       });
     }
   }]);

--- a/lib/components/slideshow/slide.js
+++ b/lib/components/slideshow/slide.js
@@ -235,17 +235,16 @@ var Slideshow = function (_Component) {
           if (_this4.willUnmount) {
             return;
           }
+          var newIndex = index < 0 ? children.length - 1 : index >= children.length ? 0 : index;
           _this4.setState({
-            index: index < 0 ? children.length - 1 : index >= children.length ? 0 : index
-          });
-
-          try {
-            if (typeof onChange === "function") {
-              onChange(index);
+            index: newIndex
+          }, function () {
+            try {
+              if (typeof onChange === "function") onChange(index, newIndex);
+            } catch (e) {
+              console.error(e);
             }
-          } catch (e) {
-            console.error(e);
-          }
+          });
         }, transitionDuration);
       }
     }

--- a/lib/components/slideshow/slide.js
+++ b/lib/components/slideshow/slide.js
@@ -209,7 +209,8 @@ var Slideshow = function (_Component) {
 
       var _props2 = this.props,
           children = _props2.children,
-          transitionDuration = _props2.transitionDuration;
+          transitionDuration = _props2.transitionDuration,
+          onChange = _props2.onChange;
 
       var existingTweens = TWEEN.default.getAll();
       if (!existingTweens.length) {
@@ -237,6 +238,14 @@ var Slideshow = function (_Component) {
           _this4.setState({
             index: index < 0 ? children.length - 1 : index >= children.length ? 0 : index
           });
+
+          try {
+            if (typeof onChange === "function") {
+              onChange(index);
+            }
+          } catch (e) {
+            console.error(e);
+          }
         }, transitionDuration);
       }
     }

--- a/lib/components/slideshow/zoom.js
+++ b/lib/components/slideshow/zoom.js
@@ -196,7 +196,9 @@ var Zoom = function (_Component) {
       var _state2 = this.state,
           children = _state2.children,
           index = _state2.index;
-      var scale = this.props.scale;
+      var _props = this.props,
+          scale = _props.scale,
+          onChange = _props.onChange;
 
       clearTimeout(this.timeout);
       var value = {
@@ -233,6 +235,14 @@ var Zoom = function (_Component) {
         _this5.timeout = setTimeout(function () {
           _this5.zoomTo((newIndex + 1) % children.length);
         }, _this5.props.duration);
+
+        try {
+          if (typeof onChange === "function") {
+            onChange(index);
+          }
+        } catch (e) {
+          console.error(e);
+        }
       });
     }
   }]);

--- a/lib/components/slideshow/zoom.js
+++ b/lib/components/slideshow/zoom.js
@@ -231,18 +231,15 @@ var Zoom = function (_Component) {
           index: newIndex
         }, function () {
           _this5.divsContainer.children[index].style.transform = 'scale(1)';
+          try {
+            if (typeof onChange === "function") onChange(index, newIndex);
+          } catch (e) {
+            console.error(e);
+          }
         });
         _this5.timeout = setTimeout(function () {
           _this5.zoomTo((newIndex + 1) % children.length);
         }, _this5.props.duration);
-
-        try {
-          if (typeof onChange === "function") {
-            onChange(index);
-          }
-        } catch (e) {
-          console.error(e);
-        }
       });
     }
   }]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slideshow-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slideshow-image",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Femi Oladeji",
   "description": "An image slideshow with react",
   "keywords": [

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -121,6 +121,7 @@ class Fade extends Component {
 
   fadeImages(newIndex) {
     let { children, index } = this.state;
+    let { onChange } = this.props;
     clearTimeout(this.timeout);
     const value = { opacity: 0 };
 
@@ -152,6 +153,13 @@ class Fade extends Component {
       this.timeout = setTimeout(() => {
         this.fadeImages((newIndex + 1) % children.length);
       }, this.props.duration);
+      
+      try{
+        if(typeof(onChange) === "function"){
+          onChange(index);
+        }
+      }
+      catch(e){ console.error(e) }
     });
   }
 }

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -149,17 +149,15 @@ class Fade extends Component {
       }
       this.setState({
         index: newIndex
+      }, () => {
+        try{
+          if(typeof onChange === "function") onChange(index, newIndex);
+        }
+        catch(e){ console.error(e) }
       });
       this.timeout = setTimeout(() => {
         this.fadeImages((newIndex + 1) % children.length);
       }, this.props.duration);
-      
-      try{
-        if(typeof(onChange) === "function"){
-          onChange(index);
-        }
-      }
-      catch(e){ console.error(e) }
     });
   }
 }

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -128,7 +128,7 @@ class Slideshow extends Component {
   }
 
   slideImages(index) {
-    let { children, transitionDuration } = this.props;
+    let { children, transitionDuration, onChange } = this.props;
     const existingTweens = TWEEN.default.getAll();
     if (!existingTweens.length) {
       clearTimeout(this.timeout);
@@ -158,6 +158,13 @@ class Slideshow extends Component {
           index:
             index < 0 ? children.length - 1 : index >= children.length ? 0 : index
         });
+        
+        try{
+          if(typeof(onChange) === "function"){
+            onChange(index);
+          }
+        }
+        catch(e){ console.error(e) }
       }, transitionDuration);
     }
   }

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -154,17 +154,15 @@ class Slideshow extends Component {
         if (this.willUnmount) {
           return;
         }
+        let newIndex = index < 0 ? children.length - 1 : index >= children.length ? 0 : index;
         this.setState({
-          index:
-            index < 0 ? children.length - 1 : index >= children.length ? 0 : index
-        });
-        
-        try{
-          if(typeof(onChange) === "function"){
-            onChange(index);
+          index: newIndex
+        }, () => {
+          try{
+            if(typeof onChange === "function") onChange(index, newIndex);
           }
-        }
-        catch(e){ console.error(e) }
+          catch(e){ console.error(e) }
+        });
       }, transitionDuration);
     }
   }

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -155,17 +155,14 @@ class Zoom extends Component {
         index: newIndex
       }, () => {
         this.divsContainer.children[index].style.transform = `scale(1)`;
+        try{
+          if(typeof onChange === "function") onChange(index, newIndex);
+        }
+        catch(e){ console.error(e) }
       });
       this.timeout = setTimeout(() => {
         this.zoomTo((newIndex + 1) % children.length);
       }, this.props.duration);
-      
-      try{
-        if(typeof(onChange) === "function"){
-          onChange(index);
-        }
-      }
-      catch(e){ console.error(e) }
     });
   }
 }

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -121,7 +121,7 @@ class Zoom extends Component {
 
   zoomTo(newIndex) {
     let { children, index } = this.state;
-    const { scale } = this.props;
+    const { scale, onChange } = this.props;
     clearTimeout(this.timeout);
     const value = {
       opacity: 0,
@@ -135,7 +135,7 @@ class Zoom extends Component {
       }
       requestAnimationFrame(animate);
       TWEEN.default.update();
-    }
+    };
 
     animate();
 
@@ -159,6 +159,13 @@ class Zoom extends Component {
       this.timeout = setTimeout(() => {
         this.zoomTo((newIndex + 1) % children.length);
       }, this.props.duration);
+      
+      try{
+        if(typeof(onChange) === "function"){
+          onChange(index);
+        }
+      }
+      catch(e){ console.error(e) }
     });
   }
 }


### PR DESCRIPTION
Currently z-index of each slide is not set.
When you want to add button on each slide, because of z-index unset, you cannot click the button.

To resolve this issue, I added `onChange` props to components.

Expected usage
```
<Fade onChange={ (oldIndex, newIndex) => {
             // Change z-index of oldIndex to 0
             ...
             // Change z-index of newIndex to 1
             ...
           }}
      {...props}
>
...
</Fade>
```