### PR TITLE
Allow indicators to be customizable

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@ __mocks__
 node_modules
 .circleci
 webpack.config.js
+webpack.config.dist.js
 LICENSE
 test-utils.js
 .github

--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ node_modules
 webpack.config.js
 LICENSE
 test-utils.js
+.github

--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ const Slideshow = () => {
     )
 }
 ```
+
+## Customizing Indciators
+The indicator can be customizes to what you want. To customize it, set the indicators prop to a function that returns the element you want. The function accepts an index parameter.
+```js
+{
+  indicators: (i) => (
+    <div
+      style={{
+        width: "30px",
+        color: "blue",
+        textAlign: "center",
+        cursor: "pointer",
+        border: "1px blue solid"
+      }}
+    >
+      {i + 1}
+    </div>
+}
+),
+```
 ## CSS
 
 This is what my css looks like. You can customize this to your own taste
@@ -268,7 +288,7 @@ HTML properties like className, data-* attributes and others will be applied to 
 | transitionDuration  | integer     | 1000          | Determines how long the transition takes                                                   |
 | defaultIndex        | integer     | 0             | Specifies the first slide to display                                                       |
 | infinite            | boolean     | true          | Specifies if the transition should loop throughout      |
-| indicators          | boolean     | false         | For specifying if there should be dots below the slideshow                                 |
+| indicators          | boolean or function     | false         | For specifying if there should be dots below the slideshow. If function, it will render the returned element                                |
 | scale               | number      |               | *Required* when using zoom to specify the scale the current slide should be zoomed to      |
 | arrows              | boolean     | true          | Determines if there should be a navigational arrow for going to the next or previous slide |
 | autoplay            | boolean     | true          | Responsible for determining if the slideshow should start automatically                    |

--- a/README.md
+++ b/README.md
@@ -157,21 +157,22 @@ const Slideshow = () => {
 The indicator can be customizes to what you want. To customize it, set the indicators prop to a function that returns the element you want. The function accepts an index parameter.
 ```js
 {
-  indicators: (i) => (
+  indicators: i => (
     <div
       style={{
-        width: "30px",
-        color: "blue",
-        textAlign: "center",
-        cursor: "pointer",
-        border: "1px blue solid"
+        width: '30px',
+        color: 'blue',
+        textAlign: 'center',
+        cursor: 'pointer',
+        border: '1px blue solid'
       }}
     >
       {i + 1}
     </div>
-}
+  )
 ),
 ```
+
 ## CSS
 
 This is what my css looks like. You can customize this to your own taste

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slideshow-image",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "author": "Femi Oladeji",
   "description": "An image slideshow with react",
   "files": [

--- a/src/App.js
+++ b/src/App.js
@@ -29,13 +29,25 @@ class App extends Component {
       duration: 5000,
       transitionDuration: 500,
       infinite: true,
-      indicators: true,
       pauseOnHover: true,
       onChange: (oldIndex, newIndex) => {
         console.log(
           `Slide transition finished from ${oldIndex} to ${newIndex}`
         );
-      }
+      },
+      indicators: i => (
+        <div
+          style={{
+            width: '30px',
+            color: 'blue',
+            textAlign: 'center',
+            cursor: 'pointer',
+            border: '1px blue solid'
+          }}
+        >
+          {i + 1}
+        </div>
+      )
     };
 
     const fadeProperties = {
@@ -65,7 +77,7 @@ class App extends Component {
       transitionDuration: 500,
       indicators: true,
       scale: 1.4,
-      pauseOnHover: true,
+      pauseOnHover: true
     };
     const { slideImages, zoomOutImages, fadeImages } = this.state;
     return (

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -143,9 +143,7 @@ class Fade extends Component {
           <div
             key={key}
             data-key={key}
-            className={`${className} ${
-              this.state.index === key ? 'active' : ''
-            }`}
+            className={`${className} ${this.state.index === key && 'active'}`}
             onClick={this.navigate}
           >
             {isCustomIndicator && this.props.indicators(key)}
@@ -168,7 +166,7 @@ class Fade extends Component {
         >
           {arrows && (
             <div
-              className={`nav ${index <= 0 && !infinite ? 'disabled' : ''}`}
+              className={`nav ${index <= 0 && !infinite && 'disabled'}`}
               data-type="prev"
               onClick={this.preFade}
             >
@@ -199,9 +197,9 @@ class Fade extends Component {
           </div>
           {arrows && (
             <div
-              className={`nav ${
-                index === children.length - 1 && !infinite ? 'disabled' : ''
-              }`}
+              className={`nav ${index === children.length - 1 &&
+                !infinite &&
+                'disabled'}`}
               data-type="next"
               onClick={this.preFade}
             >

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -116,7 +116,7 @@ class Fade extends Component {
     this.fadeImages(index === 0 ? children.length - 1 : index - 1);
   }
 
-  navigate({ target: { dataset } }) {
+  navigate({ currentTarget: { dataset } }) {
     if (dataset.key != this.state.index) {
       this.goTo(parseInt(dataset.key));
     }
@@ -132,6 +132,27 @@ class Fade extends Component {
     } else {
       this.goNext();
     }
+  }
+
+  showIndicators() {
+    const isCustomIndicator = typeof this.props.indicators !== 'boolean';
+    const className = !isCustomIndicator && 'each-slideshow-indicator';
+    return (
+      <div className="indicators">
+        {this.props.children.map((each, key) => (
+          <div
+            key={key}
+            data-key={key}
+            className={`${className} ${
+              this.state.index === key ? 'active' : ''
+            }`}
+            onClick={this.navigate}
+          >
+            {isCustomIndicator && this.props.indicators(key)}
+          </div>
+        ))}
+      </div>
+    );
   }
 
   render() {
@@ -188,18 +209,7 @@ class Fade extends Component {
             </div>
           )}
         </div>
-        {indicators && (
-          <div className="indicators">
-            {children.map((each, key) => (
-              <div
-                key={key}
-                data-key={key}
-                className={index === key ? 'active' : ''}
-                onClick={this.navigate}
-              />
-            ))}
-          </div>
-        )}
+        {indicators && this.showIndicators()}
       </div>
     );
   }
@@ -277,7 +287,7 @@ Fade.propTypes = {
   duration: PropTypes.number,
   transitionDuration: PropTypes.number,
   defaultIndex: PropTypes.number,
-  indicators: PropTypes.bool,
+  indicators: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   arrows: PropTypes.bool,
   autoplay: PropTypes.bool,
   infinite: PropTypes.bool,

--- a/src/lib/components/slideshow/general.css
+++ b/src/lib/components/slideshow/general.css
@@ -68,7 +68,7 @@
   margin-top: 20px;
 }
 
-.react-slideshow-container + div.indicators > div {
+.react-slideshow-container + div.indicators > .each-slideshow-indicator {
   width: 7px;
   height: 7px;
   margin: 0 5px 10px;
@@ -77,10 +77,10 @@
   cursor: pointer;
 }
 
-.react-slideshow-container + div.indicators > div:hover {
+.react-slideshow-container + div.indicators > .each-slideshow-indicator:hover {
   background: #666;
 }
 
-.react-slideshow-container + div.indicators > div.active {
+.react-slideshow-container + div.indicators > .each-slideshow-indicator.active {
   background: #000;
 }

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -134,9 +134,7 @@ class Slideshow extends Component {
           <div
             key={key}
             data-key={key}
-            className={`${className} ${
-              this.state.index === key ? 'active' : ''
-            }`}
+            className={`${className} ${this.state.index === key && 'active'}`}
             onClick={this.goToSlide}
           >
             {isCustomIndicator && this.props.indicators(key)}
@@ -163,7 +161,7 @@ class Slideshow extends Component {
         >
           {arrows && (
             <div
-              className={`nav ${index <= 0 && !infinite ? 'disabled' : ''}`}
+              className={`nav ${index <= 0 && !infinite && 'disabled'}`}
               data-type="prev"
               onClick={this.moveSlides}
             >
@@ -194,9 +192,9 @@ class Slideshow extends Component {
           </div>
           {arrows && (
             <div
-              className={`nav ${
-                index === children.length - 1 && !infinite ? 'disabled' : ''
-              }`}
+              className={`nav ${index === children.length - 1 &&
+                !infinite &&
+                'disabled'}`}
               data-type="next"
               onClick={this.moveSlides}
             >

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -99,8 +99,8 @@ class Slideshow extends Component {
     }
   }
 
-  goToSlide({ target }) {
-    this.goTo(parseInt(target.dataset.key));
+  goToSlide({ currentTarget }) {
+    this.goTo(parseInt(currentTarget.dataset.key));
   }
 
   goTo(index) {
@@ -123,6 +123,27 @@ class Slideshow extends Component {
       return;
     }
     this.slideImages(index - 1);
+  }
+
+  showIndicators() {
+    const isCustomIndicator = typeof this.props.indicators !== 'boolean';
+    const className = !isCustomIndicator && 'each-slideshow-indicator';
+    return (
+      <div className="indicators">
+        {this.props.children.map((_, key) => (
+          <div
+            key={key}
+            data-key={key}
+            className={`${className} ${
+              this.state.index === key ? 'active' : ''
+            }`}
+            onClick={this.goToSlide}
+          >
+            {isCustomIndicator && this.props.indicators(key)}
+          </div>
+        ))}
+      </div>
+    );
   }
 
   render() {
@@ -183,18 +204,7 @@ class Slideshow extends Component {
             </div>
           )}
         </div>
-        {indicators && (
-          <div className="indicators">
-            {children.map((each, key) => (
-              <div
-                key={key}
-                data-key={key}
-                className={index === key ? 'active' : ''}
-                onClick={this.goToSlide}
-              />
-            ))}
-          </div>
-        )}
+        {indicators && this.showIndicators()}
       </div>
     );
   }
@@ -274,7 +284,7 @@ Slideshow.propTypes = {
   transitionDuration: PropTypes.number,
   defaultIndex: PropTypes.number,
   infinite: PropTypes.bool,
-  indicators: PropTypes.bool,
+  indicators: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   autoplay: PropTypes.bool,
   arrows: PropTypes.bool,
   onChange: PropTypes.func,

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -144,9 +144,7 @@ class Zoom extends Component {
           <div
             key={key}
             data-key={key}
-            className={`${className} ${
-              this.state.index === key ? 'active' : ''
-            }`}
+            className={`${className} ${this.state.index === key && 'active'}`}
             onClick={this.navigate}
           >
             {isCustomIndicator && this.props.indicators(key)}
@@ -169,7 +167,7 @@ class Zoom extends Component {
         >
           {arrows && (
             <div
-              className={`nav ${index <= 0 && !infinite ? 'disabled' : ''}`}
+              className={`nav ${index <= 0 && !infinite && 'disabled'}`}
               data-type="prev"
               onClick={this.preZoom}
             >
@@ -200,9 +198,9 @@ class Zoom extends Component {
           </div>
           {arrows && (
             <div
-              className={`nav ${
-                index === children.length - 1 && !infinite ? 'disabled' : ''
-              }`}
+              className={`nav ${index === children.length - 1 &&
+                !infinite &&
+                'disabled'}`}
               data-type="next"
               onClick={this.preZoom}
             >

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -121,7 +121,7 @@ class Zoom extends Component {
     this.zoomTo(index);
   }
 
-  navigate({ target: { dataset } }) {
+  navigate({ currentTarget: { dataset } }) {
     if (dataset.key != this.state.index) {
       this.goTo(parseInt(dataset.key));
     }
@@ -133,6 +133,27 @@ class Zoom extends Component {
     } else {
       this.goNext();
     }
+  }
+
+  showIndicators() {
+    const isCustomIndicator = typeof this.props.indicators !== 'boolean';
+    const className = !isCustomIndicator && 'each-slideshow-indicator';
+    return (
+      <div className="indicators">
+        {this.props.children.map((each, key) => (
+          <div
+            key={key}
+            data-key={key}
+            className={`${className} ${
+              this.state.index === key ? 'active' : ''
+            }`}
+            onClick={this.navigate}
+          >
+            {isCustomIndicator && this.props.indicators(key)}
+          </div>
+        ))}
+      </div>
+    );
   }
 
   render() {
@@ -189,18 +210,7 @@ class Zoom extends Component {
             </div>
           )}
         </div>
-        {indicators && (
-          <div className="indicators">
-            {children.map((each, key) => (
-              <div
-                key={key}
-                data-key={key}
-                className={index === key ? 'active' : ''}
-                onClick={this.navigate}
-              />
-            ))}
-          </div>
-        )}
+        {indicators && this.showIndicators()}
       </div>
     );
   }
@@ -290,7 +300,7 @@ Zoom.propTypes = {
   duration: PropTypes.number,
   transitionDuration: PropTypes.number,
   defaultIndex: PropTypes.number,
-  indicators: PropTypes.bool,
+  indicators: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
   scale: PropTypes.number.isRequired,
   arrows: PropTypes.bool,
   autoplay: PropTypes.bool,


### PR DESCRIPTION
Allow slideshow indicators to be customizable. The `indicators` props can be a function that returns an element. The element will be rendered instead of the default indicators that happens when the `indicators` prop is set to `true`

```js
{
  indicators: i => (
    <div
      style={{
        width: '30px',
        color: 'blue',
        textAlign: 'center',
        cursor: 'pointer',
        border: '1px blue solid'
      }}
    >
      {i + 1}
    </div>
  )
),
```

![Screenshot 2020-05-27 at 00 45 04](https://user-images.githubusercontent.com/17332992/82957499-60c97800-9fb3-11ea-901f-c3c54a92000d.png)

This PR addresses one of the issues raised here https://github.com/femioladeji/react-slideshow/issues/72#issuecomment-634245177
