### PR TITLE
fix typo in fade_effect map function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ const Slideshow = () => {
   return (
     <div className="slide-container">
       <Fade>
-        {fadeImages.map(fadeImage, index) => (
+        {fadeImages.map((fadeImage, index) => (
           <div className="each-fade" key={index}>
             <div className="image-container">
               <img src={fadeImage.url} />
             </div>
             <h2>{fadeImage.caption}</h2>
           </div>
-        )}
+        ))}
       </Fade>
     </div>
   )


### PR DESCRIPTION
### Reference Issues/PRs

None

### What does this implement/fix? Explain your changes.

This is a documentation fix in the Fade Effect map function those parentheses are not balancing thus leading to an error when used.

### Any other comments?

No