### PR TITLE
fix: macos laggy [#158]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-slideshow-image",
       "version": "3.7.0",
       "dependencies": {
-        "@tweenjs/tween.js": "^18.1.2",
+        "@tweenjs/tween.js": "^18.6.4",
         "resize-observer-polyfill": "^1.5.1"
       },
       "devDependencies": {
@@ -2848,9 +2848,9 @@
       }
     },
     "node_modules/@tweenjs/tween.js": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.1.2.tgz",
-      "integrity": "sha512-RtawUhuD6aO8hbjaa4D4wK6Wmvf3h990oa2B7NNe58mesLu5P6MM5rZ/Hg28gOBQgZawu899qyPZ6/37OJppOA=="
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
+      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.7",
@@ -22142,9 +22142,9 @@
       "dev": true
     },
     "@tweenjs/tween.js": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.1.2.tgz",
-      "integrity": "sha512-RtawUhuD6aO8hbjaa4D4wK6Wmvf3h990oa2B7NNe58mesLu5P6MM5rZ/Hg28gOBQgZawu899qyPZ6/37OJppOA=="
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
+      "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ=="
     },
     "@types/babel__core": {
       "version": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prepublishOnly": "NODE_ENV=production babel src --out-dir lib --copy-files && npm run build"
   },
   "dependencies": {
-    "@tweenjs/tween.js": "^18.1.2",
+    "@tweenjs/tween.js": "^18.6.4",
     "resize-observer-polyfill": "^1.5.1"
   }
 }


### PR DESCRIPTION
I saw issue #158 and I decided to check it out because I'm using MacOS. I updated `tween.js` version and I have the impression that it works better now. I don't see MacOS lag in Safari and Chrome.