### PR TITLE
Fix the issue of the next arrow being disabled when responsive is enabled.

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -75,11 +75,14 @@ export const showPreviousArrow = (
 export const showNextArrow = (
     properties: FadeProps | SlideProps | ZoomProps,
     currentIndex: number,
-    moveSlides: ButtonClick
+    moveSlides: ButtonClick,
+    responsiveSettings?: Responsive
 ) => {
     const { nextArrow, infinite, children } = properties;
     let slidesToScroll = 1;
-    if ('slidesToScroll' in properties) {
+    if (responsiveSettings) {
+        slidesToScroll = responsiveSettings?.settings.slidesToScroll;
+    } else if ('slidesToScroll' in properties) {
         slidesToScroll = properties.slidesToScroll || 1;
     }
     const isDisabled = currentIndex >= React.Children.count(children) - slidesToScroll && !infinite;

--- a/src/slide.tsx
+++ b/src/slide.tsx
@@ -410,7 +410,7 @@ export const Slide = React.forwardRef<SlideshowRef, SlideProps>((props, ref) => 
                         {renderTrailingSlides()}
                     </div>
                 </div>
-                {props.arrows && showNextArrow(props, index, moveSlides)}
+                {props.arrows && showNextArrow(props, index, moveSlides, responsiveSettings)}
             </div>
             {!!props.indicators && showIndicators(props, index, goToSlide, responsiveSettings)}
         </div>


### PR DESCRIPTION
When the responsive setting is enabled, the `slidesToScroll` should use the value from responsive settings; otherwise, it will be unexpectedly disabled.